### PR TITLE
feat: add linear transistor support

### DIFF
--- a/lib/stamping/stampTransconductanceComplex.ts
+++ b/lib/stamping/stampTransconductanceComplex.ts
@@ -1,0 +1,40 @@
+import { Complex } from "../math/Complex"
+import type { CircuitNodeIndex } from "../parsing/parseNetlist"
+
+function stampTransconductanceComplex(
+  A: Complex[][],
+  nidx: CircuitNodeIndex,
+  nPlus: number,
+  nMinus: number,
+  ctrlPlus: number,
+  ctrlMinus: number,
+  gm: Complex,
+) {
+  if (gm.re === 0 && gm.im === 0) return
+  const outPlus = nidx.matrixIndexOfNode(nPlus)
+  const outMinus = nidx.matrixIndexOfNode(nMinus)
+  const ctrlPlusIdx = nidx.matrixIndexOfNode(ctrlPlus)
+  const ctrlMinusIdx = nidx.matrixIndexOfNode(ctrlMinus)
+
+  if (outPlus >= 0) {
+    const row = A[outPlus]
+    if (!row)
+      throw new Error("Matrix row missing while stamping transconductance")
+    if (ctrlPlusIdx >= 0)
+      row[ctrlPlusIdx] = (row[ctrlPlusIdx] ?? Complex.from(0, 0)).add(gm)
+    if (ctrlMinusIdx >= 0)
+      row[ctrlMinusIdx] = (row[ctrlMinusIdx] ?? Complex.from(0, 0)).sub(gm)
+  }
+
+  if (outMinus >= 0) {
+    const row = A[outMinus]
+    if (!row)
+      throw new Error("Matrix row missing while stamping transconductance")
+    if (ctrlPlusIdx >= 0)
+      row[ctrlPlusIdx] = (row[ctrlPlusIdx] ?? Complex.from(0, 0)).sub(gm)
+    if (ctrlMinusIdx >= 0)
+      row[ctrlMinusIdx] = (row[ctrlMinusIdx] ?? Complex.from(0, 0)).add(gm)
+  }
+}
+
+export { stampTransconductanceComplex }

--- a/lib/stamping/stampTransconductanceReal.ts
+++ b/lib/stamping/stampTransconductanceReal.ts
@@ -1,0 +1,35 @@
+import type { CircuitNodeIndex } from "../parsing/parseNetlist"
+
+function stampTransconductanceReal(
+  A: number[][],
+  nidx: CircuitNodeIndex,
+  nPlus: number,
+  nMinus: number,
+  ctrlPlus: number,
+  ctrlMinus: number,
+  gm: number,
+) {
+  if (gm === 0) return
+  const outPlus = nidx.matrixIndexOfNode(nPlus)
+  const outMinus = nidx.matrixIndexOfNode(nMinus)
+  const ctrlPlusIdx = nidx.matrixIndexOfNode(ctrlPlus)
+  const ctrlMinusIdx = nidx.matrixIndexOfNode(ctrlMinus)
+
+  if (outPlus >= 0) {
+    const row = A[outPlus]
+    if (!row)
+      throw new Error("Matrix row missing while stamping transconductance")
+    if (ctrlPlusIdx >= 0) row[ctrlPlusIdx] = (row[ctrlPlusIdx] ?? 0) + gm
+    if (ctrlMinusIdx >= 0) row[ctrlMinusIdx] = (row[ctrlMinusIdx] ?? 0) - gm
+  }
+
+  if (outMinus >= 0) {
+    const row = A[outMinus]
+    if (!row)
+      throw new Error("Matrix row missing while stamping transconductance")
+    if (ctrlPlusIdx >= 0) row[ctrlPlusIdx] = (row[ctrlPlusIdx] ?? 0) - gm
+    if (ctrlMinusIdx >= 0) row[ctrlMinusIdx] = (row[ctrlMinusIdx] ?? 0) + gm
+  }
+}
+
+export { stampTransconductanceReal }

--- a/tests/basics/transistor01.test.ts
+++ b/tests/basics/transistor01.test.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "bun:test"
+import { simulate } from "lib/index"
+
+const tranBiasNetlist = `
+* Simple small-signal transistor bias network
+VCC vcc 0 DC 10
+VIN vin 0 DC 0.1
+RB vin b 100k
+RC vcc c 10k
+Q1 c b 0 GM=0.01 RPI=20k RO=100k
+
+.tran 1u 1u
+
+.end
+`
+
+test("transistor01: dc bias with small-signal model", () => {
+  const result = simulate(tranBiasNetlist)
+  if (!result.tran) throw new Error("Transient result missing")
+
+  const vb = result.tran.nodeVoltages["b"]?.at(-1)
+  const vc = result.tran.nodeVoltages["c"]?.at(-1)
+  const ic = result.tran.elementCurrents["Q1"]?.at(-1)
+
+  expect(vb).toBeDefined()
+  expect(vc).toBeDefined()
+  expect(ic).toBeDefined()
+
+  expect(vb!).toBeCloseTo(0.0166666, 6)
+  expect(vc!).toBeCloseTo(7.5757575, 6)
+  expect(ic!).toBeCloseTo(0.000242424, 9)
+})
+
+const acAmplifierNetlist = `
+* AC gain using linear transistor parameters
+VIN in 0 AC 1
+RB in b 100k
+RC 1 c 10k
+QGAIN c b 0 GM=0.01 RPI=20k RO=100k
+VCC 1 0 DC 10
+
+.ac lin 1 1k 1k
+
+.end
+`
+
+test("transistor01: ac gain matches expected small-signal solution", () => {
+  const result = simulate(acAmplifierNetlist)
+  if (!result.ac) throw new Error("AC result missing")
+
+  const vb = result.ac.nodeVoltages["b"]?.[0]
+  const vc = result.ac.nodeVoltages["c"]?.[0]
+
+  expect(vb).toBeDefined()
+  expect(vc).toBeDefined()
+
+  expect(vb!.re).toBeCloseTo(0.1666666, 6)
+  expect(vb!.im).toBeCloseTo(0, 6)
+  expect(vc!.re).toBeCloseTo(-15.151515, 5)
+  expect(vc!.im).toBeCloseTo(0, 6)
+})


### PR DESCRIPTION
## Summary
- add parsing support for Q elements with gm/rpi/ro parameters and defaults
- stamp transistor admittance and transconductance into AC and transient analyses
- add regression tests covering transistor bias and AC gain behaviour

## Testing
- bunx tsc --noEmit
- bun test --filter transistor01

------
https://chatgpt.com/codex/tasks/task_b_68e066850bdc832ea5cc49e85d614b7b